### PR TITLE
Avoid reserved word 'sampler' for Vulkan-compliant codegen in glsl libs

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -441,9 +441,9 @@ vec2 mx_latlong_projection(vec3 dir)
     return vec2(longitude, latitude);
 }
 
-vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D sampler)
+vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D tex_sampler)
 {
     vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
     vec2 uv = mx_latlong_projection(envDir);
-    return textureLod(sampler, uv, lod).rgb;
+    return textureLod(tex_sampler, uv, lod).rgb;
 }


### PR DESCRIPTION
For Vulkan-compliant codegen use 'tex_sampler' as variable name instead of reserved word 'sampler' as consistent with earlier changes in other shader libs.